### PR TITLE
Fix buggy string to long conversion (with an ugly cast)

### DIFF
--- a/include/bofdefs.h
+++ b/include/bofdefs.h
@@ -73,7 +73,7 @@ WINBASEAPI HANDLE WINAPI KERNEL32$OpenProcess(DWORD dwDesiredAccess, WINBOOL bIn
 // msvcrt
 WINBASEAPI void *__cdecl MSVCRT$calloc(size_t num, size_t size);
 WINBASEAPI void __cdecl MSVCRT$free(void *memblock);
-WINBASEAPI long __cdecl MSVCRT$strtol(const char *string, char **end_ptr, int base);
+WINBASEAPI long __cdecl MSVCRT$strtoul(const char *string, char **end_ptr, int base);
 WINBASEAPI size_t __cdecl MSVCRT$mbstowcs(wchar_t *__restrict__ _Dest, const char *__restrict__ _Source,
                                           size_t _MaxCount);
 WINBASEAPI void *__cdecl MSVCRT$malloc(size_t size);

--- a/source/entry.c
+++ b/source/entry.c
@@ -120,7 +120,7 @@ void execute(WCHAR **dispatch, char *command, int argc, char *argv[])
         {
             luid = MSVCRT$calloc(1, sizeof(LUID));
             luid->HighPart = 0;
-            luid->LowPart = MSVCRT$strtol(argValue, NULL, 16);
+            luid->LowPart = (long)MSVCRT$strtoul(argValue, NULL, 16);
             if (luid->LowPart <= 0)
             {
                 MSVCRT$free(arg);


### PR DESCRIPTION
When the LUID specified in command is greater than 0x7fffffff, the conversion from a char array to the LUID->LowPart (a signed long) fails with an error, not sure why, but the result is that LUID->LowPart has the value 0x7fffffff and this is not the actual LUID of course.

To fix the issue I used strtoul instead of strtol and casted to a long right away. This works now.